### PR TITLE
Fix KeyError related to 'src' in app

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# This file is intentionally left empty to make the `src` directory a package.


### PR DESCRIPTION
Fixes #88

Add an empty `__init__.py` file to the `src` directory to make it a package.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/classroom-transcripts/pull/89?shareId=8ec75bed-e2bd-4ffd-9f2a-b5059834ef49).