### PR TITLE
Simplify Streamlit login method across multiple files

### DIFF
--- a/src/transcript_list_view.py
+++ b/src/transcript_list_view.py
@@ -16,7 +16,7 @@ from src.utils.user_utils import (
 )
 
 if not st.experimental_user.get("is_logged_in"):
-    st.login(os.getenv("STREAMLIT_AUTH_PROVIDER", None))
+    st.login()
 
 # Initialize session state for status values if not already set
 if "transcription_statuses" not in st.session_state:
@@ -173,7 +173,7 @@ def load_table_data(_table_client):
     MIN_DATE = datetime(2000, 1, 1, tzinfo=pytz.UTC)
 
     if not user or not user.email:
-        st.login(os.getenv("STREAMLIT_AUTH_PROVIDER", None))
+       st.login()
 
     try:
         # For regular users, only fetch their items

--- a/src/upload.py
+++ b/src/upload.py
@@ -417,7 +417,7 @@ else:
     if st.button(
         "Sign In", key="sign_in_button", use_container_width=True, type="primary"
     ):
-        st.login(provider)
+        st.login()
 
 
 

--- a/src/user_profile.py
+++ b/src/user_profile.py
@@ -8,7 +8,7 @@ if st.experimental_user.get("is_logged_in"):
     # Get the user's sub (subject) ID from Auth0
     user_id = st.experimental_user.get("sub")
 else:
-    st.login(os.getenv("STREAMLIT_AUTH_PROVIDER"))
+    st.login()
 
 DEBUG = os.getenv("DEBUG", False)
 auth_provider = os.getenv("STREAMLIT_AUTH_PROVIDER", None)

--- a/src/utils/user_utils.py
+++ b/src/utils/user_utils.py
@@ -44,7 +44,7 @@ def get_user_role(user) -> Optional[UserRole]:
 def validate_user_permissions():
     """Validate user is logged in and has valid email"""
     if not st.experimental_user.get("is_logged_in"):
-        st.login(os.getenv("STREAMLIT_AUTH_PROVIDER"))
+         st.login()
 
     user = st.experimental_user
     if not user or not getattr(user, "email", None):


### PR DESCRIPTION
Remove explicit auth provider parameter from st.login() calls in various authentication-related files, using the default login method